### PR TITLE
fix(pre-commit): rework lint/format scripts and lint-staged tasks

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,7 +20,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: "npm"
       - run: npm ci
-      - run: npm run format:check
+      - run: npm run format:check:all
 
   lint:
     runs-on: ubuntu-latest
@@ -36,7 +36,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: "npm"
       - run: npm ci
-      - run: npm run lint
+      - run: npm run lint:check:all
 
   build:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# ESLint
+.eslintcache

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -1,0 +1,8 @@
+export default {
+  "*.{md,html,css,json,js}": ["npm run format:check --"],
+  "*.{vue,ts}": [
+    "npm run format:check --",
+    "npm run lint:check --",
+    () => "npm run typescript -- --noEmit", // written as a function so it runs once, not for every file
+  ],
+};

--- a/package.json
+++ b/package.json
@@ -3,21 +3,19 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
-  "lint-staged": {
-    "*.{ts,tsx,md,html,css,json}": [
-      "npm run lint --",
-      "npm run format:check --",
-      "npm run typescript --"
-    ]
-  },
   "scripts": {
     "dev": "vite",
-    "typescript": "vue-tsc",
     "build": "vue-tsc && vite build",
     "preview": "vite preview",
-    "lint": "eslint './src/**/*.{ts,vue}'",
-    "format": "prettier . --write",
-    "format:check": "prettier . --check",
+    "typescript": "vue-tsc",
+    "format": "prettier --write",
+    "format:all": "npm run format .",
+    "format:check": "prettier --check --cache",
+    "format:check:all": "npm run format:check .",
+    "lint": "eslint --cache --write",
+    "lint:all": "npm run lint -- './src/**/*.{ts,vue}'",
+    "lint:check": "eslint --cache",
+    "lint:check:all": "npm run lint:check -- './src/**/*.{ts,vue}'",
     "prepare": "husky"
   },
   "dependencies": {


### PR DESCRIPTION
* Utilisation du cache de Prettier et ESLint : ça permet de gagner du temps lors du pre-commit
* Lancement de `npm run typescript` seulement lorsqu'un fichier `.vue` ou `.ts` a changé et on ne le fait qu'une seule fois (c'est un check global du projet)